### PR TITLE
support rewriting to querystring

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,19 +29,19 @@ function rewrite(src, dst) {
   debug('rewrite %s -> %s    %s', src, dst, re);
 
   return function(ctx, next) {
-    const orig = ctx.path;
+    const orig = ctx.url;
     const m = re.exec(orig);
 
     if (m) {
-      ctx.path = dst.replace(/\$(\d+)|(?::(\w+))/g, function(_, n, name){
+      ctx.url = dst.replace(/\$(\d+)|(?::(\w+))/g, function(_, n, name){
         if (name) return m[map[name].index + 1];
         return m[n];
       });
 
-      debug('rewrite %s -> %s', orig, ctx.path);
+      debug('rewrite %s -> %s', orig, ctx.url);
 
       return next().then(function() {
-        ctx.path = orig;
+        ctx.url = orig;
       });
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -63,4 +63,17 @@ describe('new Koa-rewrite', function () {
     .get('/js/jquery.js')
     .expect('/public/assets/js/jquery.js', done);
   });
+
+  it('rewrite /one/:arg -> /two?arg=:arg', function (done) {
+    const app = new Koa();
+    app.use(differentPathHelper);
+    app.use(rewrite('/one/:arg', '/two?arg=:arg'));
+    app.use(function(ctx) {
+      ctx.body = ctx.url;
+    });
+
+    request(app.callback())
+    .get('/one/test')
+    .expect('/two?arg=test', done);
+  });
 });


### PR DESCRIPTION
this performs the rewrite on ctx.url (which includes the querystring) rather than ctx.path which does not.